### PR TITLE
Support for model_info and capabilities in show api

### DIFF
--- a/modules/client-ktor/src/commonTest/kotlin/ModelClientTest.kt
+++ b/modules/client-ktor/src/commonTest/kotlin/ModelClientTest.kt
@@ -197,7 +197,31 @@ internal class ModelClientTest {
                             },
                             "model_info": {
                                 "general.architecture": "llama",
-                            }
+                                "general.file_type": 2,
+                                "general.parameter_count": 8030261248,
+                                "general.quantization_version": 2,
+                                "llama.attention.head_count": 32,
+                                "llama.attention.head_count_kv": 8,
+                                "llama.attention.layer_norm_rms_epsilon": 0.00001,
+                                "llama.block_count": 32,
+                                "llama.context_length": 8192,
+                                "llama.embedding_length": 4096,
+                                "llama.feed_forward_length": 14336,
+                                "llama.rope.dimension_count": 128,
+                                "llama.rope.freq_base": 500000,
+                                "llama.vocab_size": 128256,
+                                "tokenizer.ggml.bos_token_id": 128000,
+                                "tokenizer.ggml.eos_token_id": 128009,
+                                "tokenizer.ggml.merges": [],
+                                "tokenizer.ggml.model": "gpt2",
+                                "tokenizer.ggml.pre": "llama-bpe",
+                                "tokenizer.ggml.token_type": [],
+                                "tokenizer.ggml.tokens": []
+                            },
+                            "capabilities": [
+                                "completion",
+                                "vision"
+                            ]
                         }""",
                         status = HttpStatusCode.OK,
                         headers {

--- a/modules/models/api/models.api
+++ b/modules/models/api/models.api
@@ -807,6 +807,21 @@ public final class org/nirmato/ollama/api/Message$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class org/nirmato/ollama/api/ModelCapability : java/lang/Enum {
+	public static final field Companion Lorg/nirmato/ollama/api/ModelCapability$Companion;
+	public static final field Completion Lorg/nirmato/ollama/api/ModelCapability;
+	public static final field Embedding Lorg/nirmato/ollama/api/ModelCapability;
+	public static final field Insert Lorg/nirmato/ollama/api/ModelCapability;
+	public static final field Tools Lorg/nirmato/ollama/api/ModelCapability;
+	public static final field Vision Lorg/nirmato/ollama/api/ModelCapability;
+	public static fun valueOf (Ljava/lang/String;)Lorg/nirmato/ollama/api/ModelCapability;
+	public static fun values ()[Lorg/nirmato/ollama/api/ModelCapability;
+}
+
+public final class org/nirmato/ollama/api/ModelCapability$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class org/nirmato/ollama/api/ModelDetails {
 	public static final field Companion Lorg/nirmato/ollama/api/ModelDetails$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
@@ -1310,19 +1325,23 @@ public final class org/nirmato/ollama/api/ShowModelRequest$ShowModelRequestBuild
 public final class org/nirmato/ollama/api/ShowModelResponse {
 	public static final field Companion Lorg/nirmato/ollama/api/ShowModelResponse$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;Ljava/util/Map;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lorg/nirmato/ollama/api/ModelDetails;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;)Lorg/nirmato/ollama/api/ShowModelResponse;
-	public static synthetic fun copy$default (Lorg/nirmato/ollama/api/ShowModelResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;ILjava/lang/Object;)Lorg/nirmato/ollama/api/ShowModelResponse;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;Ljava/util/Map;Ljava/util/List;)Lorg/nirmato/ollama/api/ShowModelResponse;
+	public static synthetic fun copy$default (Lorg/nirmato/ollama/api/ShowModelResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/nirmato/ollama/api/ModelDetails;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lorg/nirmato/ollama/api/ShowModelResponse;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapabilities ()Ljava/util/List;
 	public final fun getDetails ()Lorg/nirmato/ollama/api/ModelDetails;
 	public final fun getLicense ()Ljava/lang/String;
 	public final fun getModelFile ()Ljava/lang/String;
+	public final fun getModelInfo ()Ljava/util/Map;
 	public final fun getParameters ()Ljava/lang/String;
 	public final fun getTemplate ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/modules/models/src/commonMain/kotlin/api/ModelCapability.kt
+++ b/modules/models/src/commonMain/kotlin/api/ModelCapability.kt
@@ -1,0 +1,22 @@
+package org.nirmato.ollama.api
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public enum class ModelCapability {
+    @SerialName("completion")
+    Completion,
+
+    @SerialName("tools")
+    Tools,
+
+    @SerialName("insert")
+    Insert,
+
+    @SerialName("vision")
+    Vision,
+
+    @SerialName("embedding")
+    Embedding,
+}

--- a/modules/models/src/commonMain/kotlin/api/ShowModelResponse.kt
+++ b/modules/models/src/commonMain/kotlin/api/ShowModelResponse.kt
@@ -2,6 +2,7 @@ package org.nirmato.ollama.api
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Details about a model including model file, template, parameters, license, and system prompt.
@@ -27,4 +28,10 @@ public data class ShowModelResponse(
 
     @SerialName(value = "details")
     val details: ModelDetails? = null,
+
+    @SerialName(value = "model_info")
+    val modelInfo: Map<String, JsonElement>? = null,
+
+    @SerialName(value = "capabilities")
+    val capabilities: List<ModelCapability>? = null,
 )

--- a/oas/ollama-openapi.yaml
+++ b/oas/ollama-openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
     title: Ollama API
     description: API Spec for Ollama API. Please see https://github.com/ollama/ollama/blob/main/docs/api.md for more details.
-    version: 0.5.7
+    version: 0.6.4
 
 servers:
     -   url: http://localhost:11434/api
@@ -901,6 +901,15 @@ components:
                 quantization_level:
                     type: string
                     description: The quantization level of the model.
+        ModelCapability:
+            type: string
+            description: Capability of a model.
+            enum:
+                - completion
+                - tools
+                - insert
+                - vision
+                - embedding
         ProcessResponse:
             type: object
             description: Response class for the list running models endpoint.
@@ -988,6 +997,10 @@ components:
                     description: The default messages for the model.
                     items:
                         $ref: '#/components/schemas/Message'
+                model_info:
+                    type: object
+                    additionalProperties:
+                        type: object
         CopyModelRequest:
             description: Request class for copying a model.
             type: object


### PR DESCRIPTION
This PR enhances the `/api/show` client code.

- Updates the `ollama-openapi.yaml` file (including bumping the Ollama api version to 0.6.4 for capabilities support)
- Updates the `ShowModelResponse` and add a `ModelCapability` enum
- Updates the `ModelClientTest.kt` tests
- Dumps the api changes

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you added tests that validate the new capability or bug fix?
- [x] Does your submission align with the current code style?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/nirmato/nirmato-ollama/pulls) for the same change?
