### PR TITLE
Fix ChatClientTest's imports

### DIFF
--- a/modules/client-ktor/src/commonTest/kotlin/ChatClientTest.kt
+++ b/modules/client-ktor/src/commonTest/kotlin/ChatClientTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -20,7 +21,6 @@ import org.nirmato.ollama.api.Role.USER
 import org.nirmato.ollama.api.Tool
 import org.nirmato.ollama.api.Tool.ToolFunction
 import org.nirmato.ollama.api.Tool.ToolParameters
-import org.slf4j.MDC.put
 
 internal class ChatClientTest {
 


### PR DESCRIPTION
ChatClientTest was incorrectly importing `org.slf4j.MDC.put` instead of `kotlinx.serialization.json.put`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you added tests that validate the new capability or bug fix?
- [x] Does your submission align with the current code style?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/nirmato/nirmato-ollama/pulls) for the same change?
