### PR TITLE
configure jitpack to use JDK 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+# JitPack configuration file
+# See https://docs.jitpack.io/building/#java-version
+jdk:
+  - openjdk21


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [ ] Have you added tests that validate the new capability or bug fix?
- [ ] Does your submission align with the current code style?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/nirmato/nirmato-ollama/pulls) for the same change?

As releases for this project are rather infrequent, I use jitpack builds. However, these fail because their default JDK 8 is too old to build the project.
This PR tells jitpack to use JDK 21, so the builds work again.